### PR TITLE
fehler in getValue

### DIFF
--- a/ext/uitest/src/main/java/org/minimalj/test/headless/HeadlessTableTestFacade.java
+++ b/ext/uitest/src/main/java/org/minimalj/test/headless/HeadlessTableTestFacade.java
@@ -67,7 +67,7 @@ public class HeadlessTableTestFacade implements TableTestFacade {
 		if (cell instanceof String string) {
 			return string;
 		} else if (cell instanceof Map map) {
-			return (String)map.get("text");
+			return (String)map.get("value");
 		}
 		return null;
 	}


### PR DESCRIPTION
getValue greift auf falschen key in mal zu. "value" anstatt "text"